### PR TITLE
Fix a bug in build script

### DIFF
--- a/ProtoSDK/build.cmd
+++ b/ProtoSDK/build.cmd
@@ -18,16 +18,16 @@ if not defined buildtool (
 
 set CurrentPath=%~dp0
 if not defined TestSuiteRoot (
-	set TestSuiteRoot=%CurrentPath%..\
+	set TestSuiteRoot="%CurrentPath%..\"
 )
 
-%buildtool% %TestSuiteRoot%ProtoSDK\CryptoLib\CryptoLib.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\FileAccessService\FileAccessService.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\MS-CIFS\Cifs.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\MS-FSCC\Fscc.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\MS-NLMP\Nlmp.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\MS-SMB\Smb.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\Sspi\Sspi.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\TransportStack\TransportStack.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\Common\Common.csproj /t:Clean;Rebuild
-%buildtool% %TestSuiteRoot%ProtoSDK\Messages\Messages.csproj /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\CryptoLib\CryptoLib.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\FileAccessService\FileAccessService.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\MS-CIFS\Cifs.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\MS-FSCC\Fscc.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\MS-NLMP\Nlmp.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\MS-SMB\Smb.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\Sspi\Sspi.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\TransportStack\TransportStack.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\Common\Common.csproj" /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%ProtoSDK\Messages\Messages.csproj" /t:Clean;Rebuild

--- a/TestSuites/MS-SMB/src/Deploy/deploy.wixproj
+++ b/TestSuites/MS-SMB/src/Deploy/deploy.wixproj
@@ -180,9 +180,9 @@
   
   <Target Name="GenDeployWxsFile" DependsOnTargets="ResolveWixExtensionReferences" BeforeTargets="Compile">
     <!--Test Suite WXS files-->
-    <Exec Command='"$(WIX)\bin\heat.exe" dir $(TestSuiteRoot)\drop\TestSuites\MS-SMB\Bin -out TestSuiteBinFiles.wxs -template fragment -gg -cg TESTSUITE_BIN_FILES -dr TESTSUITE_BIN_DIR -var wix.TESTSUITE_BIN_DIR -sreg -sfrag -srd' />
+    <Exec Command='"$(WIX)\bin\heat.exe" dir "$(TestSuiteRoot)\drop\TestSuites\MS-SMB\Bin" -out TestSuiteBinFiles.wxs -template fragment -gg -cg TESTSUITE_BIN_FILES -dr TESTSUITE_BIN_DIR -var wix.TESTSUITE_BIN_DIR -sreg -sfrag -srd' />
     <Exec Command='"$(WIX)\bin\heat.exe" dir ..\Batch -out TestSuiteBatchFiles.wxs -template fragment -gg -cg TESTSUITE_BATCH_FILES -dr TESTSUITE_BATCH_DIR -var wix.TESTSUITE_BATCH_DIR -sreg -sfrag -srd' />
-    <Exec Command='"$(WIX)\bin\heat.exe" dir $(TestSuiteRoot)\drop\TestSuites\MS-SMB\Scripts -out TestSuiteScripts.wxs -template fragment -gg -cg TESTSUITE_SCRIPTS_FILES -dr TESTSUITE_SCRIPTS_DIR -var wix.TESTSUITE_SCRIPTS_DIR -sreg -sfrag -srd' />
+    <Exec Command='"$(WIX)\bin\heat.exe" dir "$(TestSuiteRoot)\drop\TestSuites\MS-SMB\Scripts" -out TestSuiteScripts.wxs -template fragment -gg -cg TESTSUITE_SCRIPTS_FILES -dr TESTSUITE_SCRIPTS_DIR -var wix.TESTSUITE_SCRIPTS_DIR -sreg -sfrag -srd' />
   </Target> 
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(TargetDir)en-us\$(TargetFileName)" DestinationFolder="$(TestSuiteRoot)\drop\TestSuites\MS-SMB\deploy\" />

--- a/TestSuites/MS-SMB/src/build.cmd
+++ b/TestSuites/MS-SMB/src/build.cmd
@@ -49,10 +49,10 @@ if not defined TestSuiteRoot (
 	set TestSuiteRoot=%CurrentPath%..\..\..\
 )
 
-%buildtool% %TestSuiteRoot%TestSuites\MS-SMB\src\MS-SMB_Server.sln /t:clean
-if exist %TestSuiteRoot%drop\TestSuites\MS-SMB (
- rd /s /q %TestSuiteRoot%drop\TestSuites\MS-SMB
+%buildtool% "%TestSuiteRoot%TestSuites\MS-SMB\src\MS-SMB_Server.sln" /t:clean
+if exist "%TestSuiteRoot%drop\TestSuites\MS-SMB" (
+ rd /s /q "%TestSuiteRoot%drop\TestSuites\MS-SMB"
 )
 
-%buildtool% %TestSuiteRoot%TestSuites\MS-SMB\src\deploy\deploy.wixproj /t:Clean;Rebuild
+%buildtool% "%TestSuiteRoot%TestSuites\MS-SMB\src\deploy\deploy.wixproj" /t:Clean;Rebuild
 

--- a/buildall.cmd
+++ b/buildall.cmd
@@ -5,8 +5,8 @@
 
 set TestSuiteRoot=%~dp0
 
-if exist %TestSuiteRoot%drop (
- rd /s /q %TestSuiteRoot%drop
+if exist "%TestSuiteRoot%drop" (
+ rd /s /q "%TestSuiteRoot%drop"
 )
 
 call ProtoSDK\build.cmd


### PR DESCRIPTION
If there's a space in the name of work folder, build will fail. This commit fixes this bug.