### PR TITLE
[MS-RDPEDYC]Fix bug: Always got VERSION1 while receiving ExchangeCapabilities message from RDP Server

### DIFF
--- a/ProtoSDK/MS-RDPEDYC/Client/RdpedycClient.cs
+++ b/ProtoSDK/MS-RDPEDYC/Client/RdpedycClient.cs
@@ -112,11 +112,11 @@ namespace Microsoft.Protocols.TestTools.StackSdk.RemoteDesktop.Rdpedyc
 
             if(pdu is CapsVer1ReqDvcPdu)
             {
-                version = DYNVC_CAPS_Version.VERSION1;
+                version = (DYNVC_CAPS_Version)(((CapsVer1ReqDvcPdu)pdu).Version);
             }
             else if(pdu is CapsVer2ReqDvcPdu)
             {
-                version = DYNVC_CAPS_Version.VERSION2;
+                version = (DYNVC_CAPS_Version)(((CapsVer2ReqDvcPdu)pdu).Version);
             }
 
             this.SendDVCCapResponsePDU(version);

--- a/TestSuites/RDP/Server/src/Adapter/RDPBCGR/RdpbcgrAdapter_Sequences.cs
+++ b/TestSuites/RDP/Server/src/Adapter/RDPBCGR/RdpbcgrAdapter_Sequences.cs
@@ -297,11 +297,11 @@ namespace Microsoft.Protocols.TestSuites.Rdpbcgr
             DYNVC_CAPS_Version version = DYNVC_CAPS_Version.VERSION3;
             if (pdu is CapsVer1ReqDvcPdu)
             {
-                version = DYNVC_CAPS_Version.VERSION1;
+                version = (DYNVC_CAPS_Version)(((CapsVer1ReqDvcPdu)pdu).Version);
             }
             else if (pdu is CapsVer2ReqDvcPdu)
             {
-                version = DYNVC_CAPS_Version.VERSION2;
+                version = (DYNVC_CAPS_Version)(((CapsVer2ReqDvcPdu)pdu).Version);
             }
 
             // Response a RDPEDYC caps response PDU


### PR DESCRIPTION
[Solution]   RDP_Server.sln
[TestCase] S1_EDYC_SendUncompressedData & S1_EDYC_SendCompressedDataSequence 
[Problem] Test Suite always got VERSION1 while receiving ExchangeCapabilities message from RDPServer
[Reason] RdpedycClient::ExchangeCapabilities() got incorrect version number from ExchangeCapabilites message which send by RDP Server.
[Patch Diff]
diff --git a/ProtoSDK/MS-RDPEDYC/Client/RdpedycClient.cs b/ProtoSDK/MS-RDPEDYC/Client/RdpedycClient.cs
index f6c1d0e3..72816397 100644
--- a/ProtoSDK/MS-RDPEDYC/Client/RdpedycClient.cs
+++ b/ProtoSDK/MS-RDPEDYC/Client/RdpedycClient.cs
@@ -112,11 +112,11 @@ namespace Microsoft.Protocols.TestTools.StackSdk.RemoteDesktop.Rdpedyc

             if(pdu is CapsVer1ReqDvcPdu)
             {
-                version = DYNVC_CAPS_Version.VERSION1;
+                version = (DYNVC_CAPS_Version)(((CapsVer1ReqDvcPdu)pdu).Version);
             }
             else if(pdu is CapsVer2ReqDvcPdu)
             {
-                version = DYNVC_CAPS_Version.VERSION2;
+                version = (DYNVC_CAPS_Version)(((CapsVer2ReqDvcPdu)pdu).Version);
             }

             this.SendDVCCapResponsePDU(version);