### PR TITLE
[MS-RDPRFX] fix invalid channelId for blockType WBT_CONTEXT

### DIFF
--- a/ProtoSDK/MS-RDPRFX/Server/RdprfxServer.cs
+++ b/ProtoSDK/MS-RDPRFX/Server/RdprfxServer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Protocols.TestTools.StackSdk.RemoteDesktop.Rdprfx
             rfxContext.CodecChannelT.blockType = blockType_Value.WBT_CONTEXT;
             rfxContext.CodecChannelT.blockLen = 13;
             rfxContext.CodecChannelT.codecId = 0x01;
-            rfxContext.CodecChannelT.channelId = 0x00;
+            rfxContext.CodecChannelT.channelId = 0xFF;
             rfxContext.ctxId = 0x00;
             rfxContext.tileSize = 0x0040;
 

--- a/ProtoSDK/MS-RDPRFX/Types/Enums.cs
+++ b/ProtoSDK/MS-RDPRFX/Types/Enums.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Protocols.TestTools.StackSdk.RemoteDesktop.Rdprfx
 
         /// <summary>
         /// Negative test against field:
-        /// 2.2.2.1.2   	TS_RFX_CODEC_CHANNELT	channelId (1 byte):  An 8-bit, unsigned integer. Specifies the channel ID. This field MUST be set to 0x00.	
+        /// 2.2.2.1.2   	TS_RFX_CODEC_CHANNELT	channelId (1 byte):  An 8-bit, unsigned integer. Specifies the channel ID. If the blockType is set to WBT_CONTEXT (0xCCC3), then channelId MUST be set to 0xFF. For all other values of blockType, channelId MUST be set to 0x00.
         /// The invalid value for testing: 0x01
         /// </summary>
         TsRfxCodecChannelT_InvalidChannelId,


### PR DESCRIPTION
According to [2.2.2.1.2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/56b78b0c-6eef-40cc-b9da-96d21f197c14) channelId must be be set to `0xFF` if the blockType is set to `WBT_CONTEXT` (`0xCCC3`).