### PR TITLE
[MS-RDPEGFX] fix invalid RDPGFX_CAPVERSION_106 value

### DIFF
--- a/ProtoSDK/MS-RDPEGFX/Types/RdpegfxEnumTypes.cs
+++ b/ProtoSDK/MS-RDPEGFX/Types/RdpegfxEnumTypes.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Protocols.TestTools.StackSdk.RemoteDesktop.Rdpegfx
         /// <summary>
         /// Specifies the version of the capability, which is supported in RDP 10.6
         /// </summary>
-        RDPGFX_CAPVERSION_106 = 0x000A0600
+        RDPGFX_CAPVERSION_106 = 0x000A0601
     }
 
     public enum MaxCacheSlotNumber : int


### PR DESCRIPTION
According to [2.2.1.6](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/82e6dd00-914d-4dcc-bd17-985e1268ffb7) the `RDPGFX_CAPVERSION_106` value is `0x000A0601`.
It was incorrectly defined as `0x000A0600`