### PR TITLE
[MSRDPEGFX]: add ExpectChannelClosed adapter method

### DIFF
--- a/ProtoSDK/MS-RDPEGFX/Server/RdpegfxServer.cs
+++ b/ProtoSDK/MS-RDPEGFX/Server/RdpegfxServer.cs
@@ -70,6 +70,12 @@ namespace Microsoft.Protocols.TestTools.StackSdk.RemoteDesktop.Rdpegfx
 
         #endregion Constructor
 
+
+        public bool IsActive()
+        {
+            return rdpegfxDVC.IsActive;
+        }
+
         /// <summary>
         /// Create dynamic virtual channel.
         /// </summary>

--- a/TestSuites/RDP/Client/src/Adapter/RDPEGFX/IRdpegfxAdapter.cs
+++ b/TestSuites/RDP/Client/src/Adapter/RDPEGFX/IRdpegfxAdapter.cs
@@ -203,6 +203,11 @@ namespace Microsoft.Protocols.TestSuites.Rdpegfx
         void DeleteSurface(ushort sid);
 
         /// <summary>
+        /// Method to expect the dynamic channel do be closed.
+        /// </summary>
+        void ExpectChannelClosed();
+
+        /// <summary>
         /// Method to expect a Frame Acknowledge from client.
         /// </summary>
         void ExpectFrameAck(uint fid);

--- a/TestSuites/RDP/Client/src/Adapter/RDPEGFX/RdpegfxAdapter.cs
+++ b/TestSuites/RDP/Client/src/Adapter/RDPEGFX/RdpegfxAdapter.cs
@@ -1169,6 +1169,22 @@ namespace Microsoft.Protocols.TestSuites.Rdpegfx
         }
 
         /// <summary>
+        /// Method to expect the dynamic channel to be closed.
+        /// </summary>
+        public void ExpectChannelClosed()
+        {
+            TimeSpan timeout = waitTime;
+            DateTime endTime = DateTime.Now + timeout;
+
+            while (egfxServer.IsActive() && (DateTime.Now < endTime))
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+
+            Site.Assert.IsFalse(egfxServer.IsActive(), "RDPEGFX channel is closed");
+        }
+
+        /// <summary>
         /// Method to expect a Frame Acknowledge from client.
         /// </summary>
         public void ExpectFrameAck(uint fid)

--- a/TestSuites/RDP/Client/src/TestSuite/RDPEGFX/RdpegfxSurfaceToCacheToSurfaceTest.cs
+++ b/TestSuites/RDP/Client/src/TestSuite/RDPEGFX/RdpegfxSurfaceToCacheToSurfaceTest.cs
@@ -541,22 +541,11 @@ namespace Microsoft.Protocols.TestSuites.Rdpegfx
             this.rdpegfxAdapter.ExpectFrameAck(fid);
             this.TestSite.Assert.IsNotNull(fid, "Evit the existing cache slot should succeed.");
          
-            //Evict the existing cacheslot
-            try
-            {
-                this.TestSite.Log.Add(LogEntryKind.Comment, "Evict the existing cache slot.");
-                fid = this.rdpegfxAdapter.EvictCachEntry(cacheSlot);
-                // this.rdpegfxAdapter.ExpectFrameAck(fid);
-                this.TestSite.Assert.IsNotNull(fid, "Evit the existing cache slot should succeed.");
-            }
-            catch (Exception ex)
-            {
-                this.TestSite.Assume.Pass("Evict cache slot twice should fail as expected. The operation failed with error message: {0}.", ex.Message);
-                return;
-            }
-
-            this.TestSite.Assume.Fail("Evict a cache slot twice should fail. But the RDP client did not fail the request.");
-
+            //Evict the same cacheslot again
+            this.TestSite.Log.Add(LogEntryKind.Comment, "Evict the same cache slot again.");
+            this.TestSite.Log.Add(LogEntryKind.Comment, "Client should close the channel.");
+            fid = this.rdpegfxAdapter.EvictCachEntry(cacheSlot);
+            this.rdpegfxAdapter.ExpectChannelClosed();
         }
         [TestMethod]
         [Priority(1)]


### PR DESCRIPTION
The _evict cache entry_ test for a non existing cache slot was always inconclusive since the protocol does not specify a dedicated error pdu that could be used to detect the failure via `ExpectRdpegfxPdu`.

The obvious expected behaviour (as implemented by mstsc) is to close the egfx dynamic channel and this can be tested now.