### PR TITLE
Add missing deployment items for rdpegfx test suite

### DIFF
--- a/TestSuites/RDP/Client/src/ClientLocal.TestSettings
+++ b/TestSuites/RDP/Client/src/ClientLocal.TestSettings
@@ -71,6 +71,11 @@
     <DeploymentItem filename="Adapter\SUTControlAdapter\Run-TaskWithPSRemoting.ps1" />
     <DeploymentItem filename="Adapter\SUTControlAdapter\RDPConnectWithNegotiationApproach.ps1" />
     <DeploymentItem filename="Adapter\ShellSUTControlAdapter\RDPConnectWithNegotiationApproach.sh" />
+    <DeploymentItem filename="TestSuite\RDPEGFX\H264TestData\BaseImage\BaseImage_AVC444v2_1.bmp" />
+    <DeploymentItem filename="TestSuite\RDPEGFX\H264TestData\BaseImage\BaseImage_AVC444v2_2.bmp" />
+    <DeploymentItem filename="TestSuite\RDPEGFX\H264TestData\BaseImage\BaseImage_AVC444v2_3.bmp" />
+    <DeploymentItem filename="TestSuite\RDPEGFX\H264TestData\BaseImage\BaseImage_AVC444v2_4.bmp" />
+    <DeploymentItem filename="TestSuite\RDPEGFX\H264TestData\BaseImage\BaseImage_AVC444v2_5.bmp" />
   </Deployment>
   <Execution>
     <TestTypeSpecific>


### PR DESCRIPTION
The recently added base images for the avc444v2 test were not deployed