### PR TITLE
Align Negotiate_SMB311_Compression_CompressionAlgorithmNotSupported with latest protocol specification

### DIFF
--- a/TestSuites/FileServer/src/SMB2/TestSuite/Negotiate/Negotiation.cs
+++ b/TestSuites/FileServer/src/SMB2/TestSuite/Negotiate/Negotiation.cs
@@ -705,21 +705,22 @@ namespace Microsoft.Protocols.TestSuites.FileSharing.SMB2.TestSuite
                     BaseTestSite.Assert.AreEqual(Smb2Status.STATUS_SUCCESS, header.Status, "SUT MUST return STATUS_SUCCESS if the negotiation finished successfully.");
 
                     bool isExpectedCompressionContext = false;
-                    if (TestConfig.Platform == Platform.WindowsServerV1903 || TestConfig.Platform == Platform.WindowsServerV1909 || TestConfig.Platform >= Platform.WindowsServer2022)
+                    if (TestConfig.Platform == Platform.WindowsServerV2004 || TestConfig.Platform == Platform.WindowsServerV20H2 || TestConfig.Platform == Platform.Windows10V21H1)
                     {
-                        isExpectedCompressionContext = client.Smb2Client.CompressionInfo.CompressionIds.Length == 1 && client.Smb2Client.CompressionInfo.CompressionIds[0] == CompressionAlgorithm.NONE;
+                        isExpectedCompressionContext = client.Smb2Client.CompressionInfo.CompressionIds.Count() == 0;
                     }
                     else
                     {
-                        isExpectedCompressionContext = client.Smb2Client.CompressionInfo.CompressionIds.Count() == 0;
+                        isExpectedCompressionContext = client.Smb2Client.CompressionInfo.CompressionIds.Length == 1 && client.Smb2Client.CompressionInfo.CompressionIds[0] == CompressionAlgorithm.NONE;
                     }
 
                     BaseTestSite.Assert.IsTrue(
                         isExpectedCompressionContext,
                         "[MS-SMB2] section 3.3.5.4: If the server does not support any of the algorithms provided by the client, Connection.CompressionIds MUST be set to an empty list. " +
                         "Building an SMB2_COMPRESSION_CAPABILITIES negotiate response context: " +
-                        "If Connection.CompressionIds is empty, The server SHOULD<261> set CompressionAlgorithmCount to 0." +
-                        "<261> Windows 10 v1903, Windows 10 v1909, Windows Server v1903, and Windows Server v1909 set CompressionAlgorithmCount to 1 and CompressionAlgorithms to \"NONE\""
+                        "If Connection.CompressionIds is empty, the server SHOULD<271> set CompressionAlgorithmCount to 1, and the server SHOULD<272> set CompressionAlgorithms to \"NONE\". " +
+                        "<271> Section 3.3.5.4: Windows 10 v2004, Windows Server v2004, Windows 10 v20H2, Windows Server v20H2, and Windows 10 v21H1 operating system operating systems without [MSKB-5001391] set CompressionAlgorithmCount to 0. " +
+                        "<272> Section 3.3.5.4: Windows 10 v2004, Windows Server v2004, Windows 10 v20H2, Windows Server v20H2, and Windows 10 v21H1 operating systems without [MSKB-5001391] set CompressionAlgorithms to empty."
                         );
                 });
         }


### PR DESCRIPTION
Current Negotiate_SMB311_Compression_CompressionAlgorithmNotSupported test case in FileServer test suite is outdated as it is aligned with [MS-SMB2] v62.0 (4/7/2021). The default expectation in the test case is essentially the opposite to what is defined in current SMB protocol specification [MS-SMB2] 68.0 (9/20/2023). This PR/commit aligns the test case with latest specification documentation.